### PR TITLE
Set all times to UTC so dates match regardless of writer's timezone

### DIFF
--- a/components/assignments/available-assignments.js
+++ b/components/assignments/available-assignments.js
@@ -2,8 +2,10 @@ import {assignmentStatuses} from "../../constants/assignment-statuses";
 import {useState, useEffect} from "react";
 import * as dayjs from "dayjs";
 import * as localizedFormat from "dayjs/plugin/localizedFormat";
+import * as utc from "dayjs/plugin/utc";
 
 dayjs.extend(localizedFormat);
+dayjs.extend(utc);
 
 export default function AvailableAssignments() {
     const [assignments, setAssignments] = useState(null);
@@ -40,7 +42,7 @@ export default function AvailableAssignments() {
                       <br/>
                       <small>{assignment.request_date ? (' ✔ Request Submitted️') : 'For ' + assignment.client_name}</small>
                   </td>
-                  <td>{dayjs(assignment.writer_due_date).format("LL")}</td>
+                  <td>{dayjs(assignment.writer_due_date).utc().format("LL")}</td>
                   <td>{assignment.content_category_names}</td>
               </tr>
             ))) : (assignments && assignments.length === 0) ? (

--- a/components/assignments/my-assignments.js
+++ b/components/assignments/my-assignments.js
@@ -2,8 +2,10 @@ import {assignmentStatuses} from "../../constants/assignment-statuses";
 import {useState, useEffect} from "react";
 import * as dayjs from "dayjs";
 import * as localizedFormat from "dayjs/plugin/localizedFormat";
+import * as utc from "dayjs/plugin/utc";
 
 dayjs.extend(localizedFormat);
+dayjs.extend(utc);
 
 export default function MyAssignments() {
     const [assignments, setAssignments] = useState(null);
@@ -52,7 +54,7 @@ export default function MyAssignments() {
                         ${assignment.writer_payout}{" "}
                         {assignment.writer_paid_date ? (
                             <span
-                                title={'Payment initiated on ' + dayjs(assignment.writer_paid_date).format("LL")}>✅</span>
+                                title={'Payment initiated on ' + dayjs(assignment.writer_paid_date).utc().format("LL")}>✅</span>
                         ) : ('')}</td>
                 </tr>
             ))) : (assignments && assignments.length === 0) ? (

--- a/components/assignments/single-assignment.js
+++ b/components/assignments/single-assignment.js
@@ -1,6 +1,7 @@
 import {useState, useEffect} from "react";
 import * as dayjs from "dayjs";
 import * as localizedFormat from "dayjs/plugin/localizedFormat";
+import * as utc from "dayjs/plugin/utc";
 import {truncate} from "lodash";
 import AcceptAssignment from "../../components/assignments/accept-assignment";
 import RequestAssignment from "../../components/assignments/request-assignment";
@@ -11,6 +12,7 @@ import dynamic from 'next/dynamic';
 const ReactMarkdown= dynamic(() => import('react-markdown'),{ ssr: false });
 
 dayjs.extend(localizedFormat);
+dayjs.extend(utc);
 
 export default function SingleAssignment({assignmentId}) {
     const [assignment, setAssignment] = useState(null);
@@ -117,7 +119,7 @@ export default function SingleAssignment({assignmentId}) {
                   </>) : null}
               <tr>
                   <th>Due Date</th>
-                  <td>{dayjs(assignment.writer_due_date).format("LL")}</td>
+                  <td>{dayjs(assignment.writer_due_date).utc().format("LL")}</td>
               </tr>
               <tr>
                   <th>Deliverables</th>

--- a/pages/assignments/[assignmentId].js
+++ b/pages/assignments/[assignmentId].js
@@ -1,5 +1,4 @@
 import {useRouter} from "next/router";
-import {useEffect, useState} from "react";
 import SingleAssignment from "../../components/assignments/single-assignment";
 import AuthedOnly from "../../components/authed-only";
 

--- a/pages/assignments/available.js
+++ b/pages/assignments/available.js
@@ -1,26 +1,8 @@
-import {useEffect, useState} from "react";
-import * as dayjs from "dayjs";
-import * as localizedFormat from "dayjs/plugin/localizedFormat";
 import SecondaryNav from "../../components/navs/secondary-nav";
 import AuthedOnly from "../../components/authed-only";
 import AvailableAssignments from "../../components/assignments/available-assignments";
 
-dayjs.extend(localizedFormat);
-
 export default function Available() {
-    const getAssignments = () => {
-        const token = localStorage.getItem("ACCESS_TOKEN");
-        fetch(`/api/assignments/available`, {
-            headers: {Authorization: `Bearer ${token}`},
-        })
-            .then(resp => resp.json())
-            .then(json => setAssignments(json))
-            .catch(e => {
-                console.error(e);
-                setAssignments(false);
-            });
-    };
-
     return (
         <AuthedOnly>
           <h1 style={{textAlign: 'center'}}>Writer Portal</h1>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,5 @@
-import {useEffect, useState} from "react";
 import SecondaryNav from "../components/navs/secondary-nav";
 import AuthedOnly from "../components/authed-only";
-import { SignedIn, SignedOut, SignIn } from '@clerk/nextjs';
-import SignoutLink from "../components/navs/signout-link";
-import SigninForm from "../components/navs/signin-form";
 import MyAssignments from "../components/assignments/my-assignments";
 
 export default function Home() {


### PR DESCRIPTION
Turns out Day.js automatically converts our UTC timezones from Airtable to the user's local timezone. This was causing writers to see a different due date than we have in Airtable.

While technically correct, we've never enforced timezone differences, so I set all the due dates to UTC on the frontend.

Fixes this issue: https://trello.com/c/IwkWZ1S8/305-different-due-dates-in-airtable-vs-writer-portal